### PR TITLE
Move ALL devDependencies to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "autoprefixer": "6.7.2",
     "babel-core": "6.22.1",
+
     "babel-eslint": "7.1.1",
     "babel-jest": "18.0.0",
     "babel-loader": "6.2.10",
@@ -49,9 +50,7 @@
     "serve": "^5.1.4",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "whatwg-fetch": "2.0.2"
-  },
-  "devDependencies": {
+    "whatwg-fetch": "2.0.2",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "enzyme": "^2.8.2",
@@ -69,6 +68,7 @@
     "react-test-renderer": "^15.5.4",
     "sinon": "^2.1.0"
   },
+  "devDependencies": {},
   "scripts": {
     "start": "node scripts/start.js",
     "start:prod": "node_modules/serve/bin/serve.js -s build",


### PR DESCRIPTION
Something needs to be refactored ASAP. Why does the production build need eslint!?